### PR TITLE
タスク検索API実装（Read）

### DIFF
--- a/backend/src/main/java/com/example/taskmanagement/task/TaskController.java
+++ b/backend/src/main/java/com/example/taskmanagement/task/TaskController.java
@@ -2,6 +2,7 @@ package com.example.taskmanagement.task;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -10,14 +11,16 @@ import java.util.List;
 @RequestMapping("/api/tasks")
 public class TaskController {
 
-    private final TaskMapper taskMapper;
+    private final TaskService taskService;
 
-    public TaskController(TaskMapper taskMapper) {
-        this.taskMapper = taskMapper;
+    public TaskController(TaskService taskService) {
+        this.taskService = taskService;
     }
 
     @GetMapping
-    public List<Task> getTasks() {
-        return taskMapper.findAll();
+    public List<Task> getTasks(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String status) {
+        return taskService.search(keyword, status);
     }
 }

--- a/backend/src/main/java/com/example/taskmanagement/task/TaskMapper.java
+++ b/backend/src/main/java/com/example/taskmanagement/task/TaskMapper.java
@@ -1,10 +1,12 @@
 package com.example.taskmanagement.task;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 
 @Mapper
 public interface TaskMapper {
-    List<Task> findAll();
+    List<Task> search(@Param("keyword") String keyword,
+                      @Param("status")  String status);
 }

--- a/backend/src/main/java/com/example/taskmanagement/task/TaskService.java
+++ b/backend/src/main/java/com/example/taskmanagement/task/TaskService.java
@@ -1,0 +1,19 @@
+package com.example.taskmanagement.task;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class TaskService {
+
+    private final TaskMapper taskMapper;
+
+    public TaskService(TaskMapper taskMapper) {
+        this.taskMapper = taskMapper;
+    }
+
+    public List<Task> search(String keyword, String status) {
+        return taskMapper.search(keyword, status);
+    }
+}

--- a/backend/src/main/resources/mapper/TaskMapper.xml
+++ b/backend/src/main/resources/mapper/TaskMapper.xml
@@ -3,9 +3,17 @@
     "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.example.taskmanagement.task.TaskMapper">
 
-    <select id="findAll" resultType="Task">
+    <select id="search" resultType="Task">
         SELECT id, title, status, position, created_at, updated_at
         FROM tasks
+        <where>
+            <if test="keyword != null and keyword != ''">
+                title ILIKE '%' || #{keyword} || '%'
+            </if>
+            <if test="status != null and status != ''">
+                AND status = #{status}
+            </if>
+        </where>
         ORDER BY position
     </select>
 

--- a/db/init.sql
+++ b/db/init.sql
@@ -6,3 +6,10 @@ CREATE TABLE IF NOT EXISTS tasks (
     created_at TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+
+INSERT INTO tasks (title, status, position) VALUES
+    ('バックエンドAPIを設計する',   'DONE',        1),
+    ('MyBatisのMapper実装',        'DONE',        2),
+    ('フロントエンドのUI作成',      'IN_PROGRESS', 3),
+    ('テストコードを書く',          'TODO',        4),
+    ('本番環境へデプロイする',      'TODO',        5);


### PR DESCRIPTION
Closes #1

## 変更内容
- `db/init.sql` にテストデータ5件を追加（TODO×2, IN_PROGRESS×1, DONE×2）
- `TaskMapper.java` に `search(keyword, status)` メソッドを追加
- `TaskMapper.xml` に MyBatis 動的SQL（`<where><if>`）で ILIKE 部分一致検索を実装
- `TaskService.java` を新規作成し、Controller → Service → Mapper の3層構造に整備
- `TaskController.java` を `TaskService` 経由に変更、`@RequestParam` でクエリパラメータを受け取るよう対応

## API 仕様
- `GET /api/tasks` — 全件取得
- `GET /api/tasks?keyword=xxx` — タイトル部分一致（大文字小文字無視）
- `GET /api/tasks?status=TODO` — ステータスフィルター（TODO / IN_PROGRESS / DONE）
- `GET /api/tasks?keyword=xxx&status=xxx` — 両方組み合わせ