### PR TITLE
LombokでTaskモデルのgetter/setterを省略

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -22,6 +22,8 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-security")
 	implementation("org.mybatis.spring.boot:mybatis-spring-boot-starter:4.0.0")
 	runtimeOnly("org.postgresql:postgresql")
+	compileOnly("org.projectlombok:lombok")
+	annotationProcessor("org.projectlombok:lombok")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 	testRuntimeOnly("com.h2database:h2")

--- a/backend/src/main/java/com/taskmanagement/model/Task.java
+++ b/backend/src/main/java/com/taskmanagement/model/Task.java
@@ -1,8 +1,12 @@
 package com.taskmanagement.model;
 
+import lombok.Getter;
+import lombok.Setter;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+@Getter
+@Setter
 public class Task {
     private Integer id;
     private String title;
@@ -13,31 +17,4 @@ public class Task {
     private int position;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
-
-    public Integer getId() { return id; }
-    public void setId(Integer id) { this.id = id; }
-
-    public String getTitle() { return title; }
-    public void setTitle(String title) { this.title = title; }
-
-    public String getDescription() { return description; }
-    public void setDescription(String description) { this.description = description; }
-
-    public String getStatus() { return status; }
-    public void setStatus(String status) { this.status = status; }
-
-    public String getPriority() { return priority; }
-    public void setPriority(String priority) { this.priority = priority; }
-
-    public LocalDate getDueDate() { return dueDate; }
-    public void setDueDate(LocalDate dueDate) { this.dueDate = dueDate; }
-
-    public int getPosition() { return position; }
-    public void setPosition(int position) { this.position = position; }
-
-    public LocalDateTime getCreatedAt() { return createdAt; }
-    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
-
-    public LocalDateTime getUpdatedAt() { return updatedAt; }
-    public void setUpdatedAt(LocalDateTime updatedAt) { this.updatedAt = updatedAt; }
 }


### PR DESCRIPTION
Closes #14

## 変更内容
- `build.gradle.kts` に Lombok の `compileOnly` + `annotationProcessor` を追加
- `Task.java` の getter/setter 16メソッドを削除し `@Getter @Setter` に置き換え

## 動作確認
- `./gradlew build` が成功することを確認済み