### PR TITLE
タスクカードクリックで詳細・編集モーダルを表示し更新できる機能を追加

### DIFF
--- a/backend/src/main/java/com/taskmanagement/controller/TaskController.java
+++ b/backend/src/main/java/com/taskmanagement/controller/TaskController.java
@@ -5,7 +5,9 @@ import com.taskmanagement.service.TaskService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -28,6 +30,15 @@ public class TaskController {
             @RequestParam(required = false) String keyword,
             @RequestParam(required = false) String status) {
         return taskService.search(keyword, status);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Task> updateTask(
+            @PathVariable Integer id,
+            @RequestBody Task task) {
+        Task updated = taskService.update(id, task);
+        if (updated == null) return ResponseEntity.notFound().build();
+        return ResponseEntity.ok(updated);
     }
 
     @PostMapping

--- a/backend/src/main/java/com/taskmanagement/mapper/TaskMapper.java
+++ b/backend/src/main/java/com/taskmanagement/mapper/TaskMapper.java
@@ -12,4 +12,8 @@ public interface TaskMapper {
                       @Param("status")  String status);
 
     void insert(Task task);
+
+    Task findById(@Param("id") Integer id);
+
+    void update(Task task);
 }

--- a/backend/src/main/java/com/taskmanagement/service/TaskService.java
+++ b/backend/src/main/java/com/taskmanagement/service/TaskService.java
@@ -21,6 +21,15 @@ public class TaskService {
     }
 
     @Transactional
+    public Task update(Integer id, Task task) {
+        task.setId(id);
+        if (task.getStatus() == null || task.getStatus().isBlank()) task.setStatus("TODO");
+        if (task.getPriority() == null || task.getPriority().isBlank()) task.setPriority("MEDIUM");
+        taskMapper.update(task);
+        return taskMapper.findById(id);
+    }
+
+    @Transactional
     public Task create(Task task) {
         if (task.getStatus() == null || task.getStatus().isBlank()) task.setStatus("TODO");
         if (task.getPriority() == null || task.getPriority().isBlank()) task.setPriority("MEDIUM");

--- a/backend/src/main/resources/mapper/TaskMapper.xml
+++ b/backend/src/main/resources/mapper/TaskMapper.xml
@@ -17,6 +17,23 @@
         ORDER BY position
     </select>
 
+    <select id="findById" parameterType="int" resultType="Task">
+        SELECT id, title, description, status, priority, due_date, position, created_at, updated_at
+        FROM tasks
+        WHERE id = #{id}
+    </select>
+
+    <update id="update" parameterType="Task">
+        UPDATE tasks
+        SET title       = #{title},
+            description = #{description},
+            status      = #{status},
+            priority    = #{priority},
+            due_date    = #{dueDate},
+            updated_at  = NOW()
+        WHERE id = #{id}
+    </update>
+
     <insert id="insert" parameterType="Task"
             useGeneratedKeys="true" keyProperty="id">
         INSERT INTO tasks (title, description, status, priority, due_date, position)

--- a/frontend/src/api/taskApi.ts
+++ b/frontend/src/api/taskApi.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import type { Task, CreateTaskInput } from '../types/task';
+import type { Task, CreateTaskInput, UpdateTaskInput } from '../types/task';
 
 const api = axios.create({ baseURL: '/api' });
 
@@ -10,6 +10,18 @@ export interface SearchParams {
 
 export async function fetchTasks(params: SearchParams): Promise<Task[]> {
   const { data } = await api.get<Task[]>('/tasks', { params });
+  return data;
+}
+
+export async function updateTask(id: number, input: UpdateTaskInput): Promise<Task> {
+  const payload = {
+    title: input.title,
+    description: input.description || null,
+    status: input.status,
+    priority: input.priority,
+    dueDate: input.dueDate,
+  };
+  const { data } = await api.put<Task>(`/tasks/${id}`, payload);
   return data;
 }
 

--- a/frontend/src/components/BoardPage.tsx
+++ b/frontend/src/components/BoardPage.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
-import { fetchTasks, createTask } from '../api/taskApi';
-import type { Task, CreateTaskInput } from '../types/task';
+import { fetchTasks, createTask, updateTask } from '../api/taskApi';
+import type { Task, CreateTaskInput, UpdateTaskInput } from '../types/task';
 import Column from './Column';
 import SearchBar from './SearchBar';
 import AddTaskModal from './AddTaskModal';
+import TaskDetailModal from './TaskDetailModal';
 
 export default function BoardPage() {
   const [tasks, setTasks] = useState<Task[]>([]);
@@ -12,6 +13,7 @@ export default function BoardPage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showModal, setShowModal] = useState(false);
+  const [selectedTask, setSelectedTask] = useState<Task | null>(null);
 
   useEffect(() => {
     const timer = setTimeout(async () => {
@@ -31,6 +33,15 @@ export default function BoardPage() {
     }, 300);
     return () => clearTimeout(timer);
   }, [keyword, status]);
+
+  const handleUpdateTask = async (id: number, input: UpdateTaskInput) => {
+    await updateTask(id, input);
+    const data = await fetchTasks({
+      keyword: keyword || undefined,
+      status: status || undefined,
+    });
+    setTasks(data);
+  };
 
   const handleCreateTask = async (input: CreateTaskInput) => {
     await createTask(input);
@@ -72,15 +83,22 @@ export default function BoardPage() {
           <p className="mt-4 text-sm text-text-sub">読み込み中...</p>
         )}
         <div className="flex gap-4 mt-4 items-start overflow-x-auto pb-4">
-          <Column status="TODO" tasks={todoTasks} />
-          <Column status="IN_PROGRESS" tasks={inProgressTasks} />
-          <Column status="DONE" tasks={doneTasks} />
+          <Column status="TODO" tasks={todoTasks} onTaskClick={setSelectedTask} />
+          <Column status="IN_PROGRESS" tasks={inProgressTasks} onTaskClick={setSelectedTask} />
+          <Column status="DONE" tasks={doneTasks} onTaskClick={setSelectedTask} />
         </div>
       </div>
       {showModal && (
         <AddTaskModal
           onClose={() => setShowModal(false)}
           onSubmit={handleCreateTask}
+        />
+      )}
+      {selectedTask && (
+        <TaskDetailModal
+          task={selectedTask}
+          onClose={() => setSelectedTask(null)}
+          onSubmit={handleUpdateTask}
         />
       )}
     </div>

--- a/frontend/src/components/Column.tsx
+++ b/frontend/src/components/Column.tsx
@@ -10,9 +10,10 @@ const COLUMN_LABELS: Record<TaskStatus, string> = {
 interface Props {
   status: TaskStatus;
   tasks: Task[];
+  onTaskClick: (task: Task) => void;
 }
 
-export default function Column({ status, tasks }: Props) {
+export default function Column({ status, tasks, onTaskClick }: Props) {
   return (
     <div className="w-72 flex-shrink-0 bg-col-bg rounded-lg flex flex-col max-h-[calc(100vh-10rem)]">
       <div className="p-3 flex items-center justify-between">
@@ -25,7 +26,7 @@ export default function Column({ status, tasks }: Props) {
       </div>
       <div className="flex-1 overflow-y-auto px-2 pb-2 flex flex-col gap-2 min-h-[60px]">
         {tasks.map(task => (
-          <TaskCard key={task.id} task={task} />
+          <TaskCard key={task.id} task={task} onClick={() => onTaskClick(task)} />
         ))}
       </div>
     </div>

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -17,14 +17,15 @@ function formatDueDate(dueDate: string): { label: string; overdue: boolean } {
 
 interface Props {
   task: Task;
+  onClick?: () => void;
 }
 
-export default function TaskCard({ task }: Props) {
+export default function TaskCard({ task, onClick }: Props) {
   const priorityBadge = task.priority ? PRIORITY_BADGE[task.priority] : null;
   const due = formatDueDate(task.dueDate);
 
   return (
-    <div className="bg-surface rounded shadow-sm px-3 py-2.5 border border-transparent hover:border-border hover:-translate-y-px hover:shadow-md transition-all cursor-pointer">
+    <div className="bg-surface rounded shadow-sm px-3 py-2.5 border border-transparent hover:border-border hover:-translate-y-px hover:shadow-md transition-all cursor-pointer" onClick={onClick}>
       <p className="text-sm font-medium leading-snug break-words text-text mb-2">{task.title}</p>
       <div className="flex items-center gap-1.5 flex-wrap">
         {priorityBadge && (

--- a/frontend/src/components/TaskDetailModal.tsx
+++ b/frontend/src/components/TaskDetailModal.tsx
@@ -1,0 +1,183 @@
+import { useState } from 'react';
+import type { Task, UpdateTaskInput } from '../types/task';
+
+interface Props {
+  task: Task;
+  onClose: () => void;
+  onSubmit: (id: number, input: UpdateTaskInput) => Promise<void>;
+}
+
+export default function TaskDetailModal({ task, onClose, onSubmit }: Props) {
+  const [form, setForm] = useState<UpdateTaskInput>({
+    title: task.title,
+    description: task.description ?? '',
+    status: task.status,
+    priority: task.priority ?? 'MEDIUM',
+    dueDate: task.dueDate,
+  });
+  const [titleError, setTitleError] = useState('');
+  const [dueDateError, setDueDateError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState('');
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
+  ) => {
+    setForm(prev => ({ ...prev, [e.target.name]: e.target.value }));
+    if (e.target.name === 'title') setTitleError('');
+    if (e.target.name === 'dueDate') setDueDateError('');
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    let hasError = false;
+    if (!form.title.trim()) {
+      setTitleError('タイトルは必須です');
+      hasError = true;
+    }
+    if (!form.dueDate) {
+      setDueDateError('期日は必須です');
+      hasError = true;
+    }
+    if (hasError) return;
+    setSubmitting(true);
+    setSubmitError('');
+    try {
+      await onSubmit(task.id, { ...form, title: form.title.trim() });
+      onClose();
+    } catch {
+      setSubmitError('更新に失敗しました。もう一度お試しください。');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onMouseDown={e => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="bg-surface rounded-lg shadow-xl w-full max-w-md p-6 mx-4">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-base font-bold text-text">タスクを編集</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-text-sub hover:text-text text-lg leading-none"
+            aria-label="閉じる"
+          >
+            ×
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-4">
+          <div>
+            <label className="block text-xs font-semibold text-text mb-1">
+              タイトル <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              name="title"
+              value={form.title}
+              onChange={handleChange}
+              placeholder="タスクのタイトル"
+              className={`w-full border rounded px-3 py-2 text-sm text-text placeholder:text-text-sub focus:outline-none focus:ring-2 focus:ring-primary ${titleError ? 'border-red-500' : 'border-border'}`}
+            />
+            {titleError && (
+              <p className="mt-1 text-xs text-red-500">{titleError}</p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-xs font-semibold text-text mb-1">説明</label>
+            <textarea
+              name="description"
+              value={form.description}
+              onChange={handleChange}
+              rows={3}
+              placeholder="タスクの詳細（任意）"
+              className="w-full border border-border rounded px-3 py-2 text-sm text-text placeholder:text-text-sub focus:outline-none focus:ring-2 focus:ring-primary resize-none"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs font-semibold text-text mb-1">ステータス</label>
+            <div className="flex rounded border border-border overflow-hidden">
+              {([['TODO', 'Todo'], ['IN_PROGRESS', 'In Progress'], ['DONE', 'Done']] as const).map(([value, label]) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => setForm(prev => ({ ...prev, status: value }))}
+                  className={`flex-1 py-2 text-sm font-medium transition-colors
+                    ${form.status === value
+                      ? 'bg-green-500 text-white'
+                      : 'bg-surface text-text-sub hover:bg-bg'
+                    }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-xs font-semibold text-text mb-1">優先度</label>
+            <div className="flex rounded border border-border overflow-hidden">
+              {([['HIGH', '高'], ['MEDIUM', '中'], ['LOW', '低']] as const).map(([value, label]) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => setForm(prev => ({ ...prev, priority: value }))}
+                  className={`flex-1 py-2 text-sm font-medium transition-colors
+                    ${form.priority === value
+                      ? 'bg-green-500 text-white'
+                      : 'bg-surface text-text-sub hover:bg-bg'
+                    }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-xs font-semibold text-text mb-1">
+              期日 <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="date"
+              name="dueDate"
+              value={form.dueDate}
+              onChange={handleChange}
+              className={`w-full border rounded px-3 py-2 text-sm text-text focus:outline-none focus:ring-2 focus:ring-primary ${dueDateError ? 'border-red-500' : 'border-border'}`}
+            />
+            {dueDateError && (
+              <p className="mt-1 text-xs text-red-500">{dueDateError}</p>
+            )}
+          </div>
+
+          {submitError && (
+            <p className="text-xs text-red-500">{submitError}</p>
+          )}
+
+          <div className="flex justify-end gap-2 pt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm rounded border border-border text-text hover:bg-bg"
+            >
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="px-4 py-2 text-sm rounded bg-primary text-white hover:bg-blue-700 disabled:opacity-50"
+            >
+              {submitting ? '更新中...' : '更新'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types/task.ts
+++ b/frontend/src/types/task.ts
@@ -20,3 +20,11 @@ export interface CreateTaskInput {
   priority: Priority;
   dueDate: string;
 }
+
+export interface UpdateTaskInput {
+  title: string;
+  description: string;
+  status: TaskStatus;
+  priority: Priority;
+  dueDate: string;
+}


### PR DESCRIPTION
Closes #16

## 変更内容

### バックエンド
- `PUT /api/tasks/{id}` エンドポイントを追加
- `TaskMapper` に `findById` / `update` メソッドを追加
- `TaskMapper.xml` に SELECT by id / UPDATE SQL を追加
- `TaskService` に `update()` メソッドを追加

### フロントエンド
- `UpdateTaskInput` 型を追加
- `updateTask()` API 関数を追加
- `TaskDetailModal` コンポーネントを新規作成（編集モーダル）
- `TaskCard` に `onClick` prop を追加
- `Column` に `onTaskClick` prop を追加
- `BoardPage` に `selectedTask` 状態・`handleUpdateTask` ハンドラを追加