### PR TITLE
タスク削除機能の追加

### DIFF
--- a/backend/src/main/java/com/taskmanagement/controller/TaskController.java
+++ b/backend/src/main/java/com/taskmanagement/controller/TaskController.java
@@ -5,6 +5,7 @@ import com.taskmanagement.model.Task;
 import com.taskmanagement.service.TaskService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -53,5 +54,12 @@ public class TaskController {
     public ResponseEntity<Task> createTask(@RequestBody Task task) {
         Task created = taskService.create(task);
         return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteTask(@PathVariable Integer id) {
+        boolean deleted = taskService.delete(id);
+        if (!deleted) return ResponseEntity.notFound().build();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/taskmanagement/mapper/TaskMapper.java
+++ b/backend/src/main/java/com/taskmanagement/mapper/TaskMapper.java
@@ -16,6 +16,8 @@ public interface TaskMapper {
 
     Task findById(@Param("id") Integer id);
 
+    void deleteById(@Param("id") Integer id);
+
     void update(Task task);
 
     void updatePositionAndStatus(ReorderItem item);

--- a/backend/src/main/java/com/taskmanagement/service/TaskService.java
+++ b/backend/src/main/java/com/taskmanagement/service/TaskService.java
@@ -38,6 +38,14 @@ public class TaskService {
     }
 
     @Transactional
+    public boolean delete(Integer id) {
+        Task existing = taskMapper.findById(id);
+        if (existing == null) return false;
+        taskMapper.deleteById(id);
+        return true;
+    }
+
+    @Transactional
     public Task create(Task task) {
         if (task.getStatus() == null || task.getStatus().isBlank()) task.setStatus("TODO");
         if (task.getPriority() == null || task.getPriority().isBlank()) task.setPriority("MEDIUM");

--- a/backend/src/main/resources/mapper/TaskMapper.xml
+++ b/backend/src/main/resources/mapper/TaskMapper.xml
@@ -42,6 +42,10 @@
         WHERE id = #{id}
     </update>
 
+    <delete id="deleteById" parameterType="int">
+        DELETE FROM tasks WHERE id = #{id}
+    </delete>
+
     <insert id="insert" parameterType="Task"
             useGeneratedKeys="true" keyProperty="id">
         INSERT INTO tasks (title, description, status, priority, due_date, position)

--- a/frontend/src/api/taskApi.ts
+++ b/frontend/src/api/taskApi.ts
@@ -29,6 +29,10 @@ export async function reorderTasks(items: ReorderItem[]): Promise<void> {
   await api.patch('/tasks/reorder', items);
 }
 
+export async function deleteTask(id: number): Promise<void> {
+  await api.delete(`/tasks/${id}`);
+}
+
 export async function createTask(input: CreateTaskInput): Promise<Task> {
   const payload = {
     title: input.title,

--- a/frontend/src/components/BoardPage.tsx
+++ b/frontend/src/components/BoardPage.tsx
@@ -5,13 +5,14 @@ import {
   type DragStartEvent, type DragEndEvent, type DragOverEvent,
 } from '@dnd-kit/core';
 import { arrayMove } from '@dnd-kit/sortable';
-import { fetchTasks, createTask, updateTask, reorderTasks } from '../api/taskApi';
+import { fetchTasks, createTask, updateTask, reorderTasks, deleteTask } from '../api/taskApi';
 import type { Task, CreateTaskInput, UpdateTaskInput, TaskStatus, SortOrder, ReorderItem } from '../types/task';
 import Column from './Column';
 import SearchBar from './SearchBar';
 import AddTaskModal from './AddTaskModal';
 import TaskDetailModal from './TaskDetailModal';
 import TaskCard from './TaskCard';
+import ConfirmDialog from './ConfirmDialog';
 
 const PRIORITY_RANK: Record<string, number> = { HIGH: 0, MEDIUM: 1, LOW: 2 };
 const STATUS_VALUES: TaskStatus[] = ['TODO', 'IN_PROGRESS', 'DONE'];
@@ -60,6 +61,8 @@ export default function BoardPage() {
   const [sortOrders, setSortOrders] = useState<Record<TaskStatus, SortOrder>>(loadSortOrders);
   const [activeTask, setActiveTask] = useState<Task | null>(null);
   const [overId, setOverId] = useState<number | string | null>(null);
+  const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
+  const [deleteTargetTitle, setDeleteTargetTitle] = useState<string>('');
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
@@ -100,6 +103,25 @@ export default function BoardPage() {
       status: status || undefined,
     });
     setTasks(data);
+  };
+
+  const handleDeleteRequest = (id: number) => {
+    const task = tasks.find(t => t.id === id);
+    setDeleteTargetId(id);
+    setDeleteTargetTitle(task?.title ?? '');
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (deleteTargetId === null) return;
+    setTasks(prev => prev.filter(t => t.id !== deleteTargetId));
+    setDeleteTargetId(null);
+    setDeleteTargetTitle('');
+    await deleteTask(deleteTargetId);
+  };
+
+  const handleDeleteCancel = () => {
+    setDeleteTargetId(null);
+    setDeleteTargetTitle('');
   };
 
   const handleSort = (colStatus: TaskStatus, criterion: 'priority' | 'dueDate') => {
@@ -223,6 +245,7 @@ export default function BoardPage() {
               onSort={criterion => handleSort('TODO', criterion)}
               activeTaskId={activeTask?.id ?? null}
               overId={overId}
+              onDelete={handleDeleteRequest}
             />
             <Column
               status="IN_PROGRESS" tasks={inProgressTasks}
@@ -231,6 +254,7 @@ export default function BoardPage() {
               onSort={criterion => handleSort('IN_PROGRESS', criterion)}
               activeTaskId={activeTask?.id ?? null}
               overId={overId}
+              onDelete={handleDeleteRequest}
             />
             <Column
               status="DONE" tasks={doneTasks}
@@ -239,6 +263,7 @@ export default function BoardPage() {
               onSort={criterion => handleSort('DONE', criterion)}
               activeTaskId={activeTask?.id ?? null}
               overId={overId}
+              onDelete={handleDeleteRequest}
             />
           </div>
           <DragOverlay>
@@ -257,6 +282,13 @@ export default function BoardPage() {
           task={selectedTask}
           onClose={() => setSelectedTask(null)}
           onSubmit={handleUpdateTask}
+        />
+      )}
+      {deleteTargetId !== null && (
+        <ConfirmDialog
+          message={`「${deleteTargetTitle}」を削除してもよろしいですか？`}
+          onConfirm={handleDeleteConfirm}
+          onCancel={handleDeleteCancel}
         />
       )}
     </div>

--- a/frontend/src/components/Column.tsx
+++ b/frontend/src/components/Column.tsx
@@ -19,6 +19,7 @@ interface Props {
   onSort: (criterion: SortCriterion) => void;
   activeTaskId: number | null;
   overId: number | string | null;
+  onDelete: (id: number) => void;
 }
 
 function DropIndicator() {
@@ -30,7 +31,7 @@ function DropIndicator() {
   );
 }
 
-export default function Column({ status, tasks, sortOrder, onTaskClick, onSort, activeTaskId, overId }: Props) {
+export default function Column({ status, tasks, sortOrder, onTaskClick, onSort, activeTaskId, overId, onDelete }: Props) {
   const { setNodeRef } = useDroppable({ id: status });
   const isDragging = activeTaskId !== null;
 
@@ -70,7 +71,7 @@ export default function Column({ status, tasks, sortOrder, onTaskClick, onSort, 
             <div key={task.id} className="flex flex-col">
               {isDragging && overId === task.id && activeTaskId !== task.id && <DropIndicator />}
               <div className="mb-2">
-                <TaskCard task={task} onClick={() => onTaskClick(task)} />
+                <TaskCard task={task} onClick={() => onTaskClick(task)} onDelete={onDelete} />
               </div>
             </div>
           ))}

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -1,0 +1,34 @@
+interface Props {
+  message: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function ConfirmDialog({ message, onConfirm, onCancel }: Props) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onMouseDown={e => { if (e.target === e.currentTarget) onCancel(); }}
+    >
+      <div className="bg-surface rounded-lg shadow-xl w-full max-w-sm p-6 mx-4">
+        <p className="text-sm text-text mb-6">{message}</p>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-4 py-2 text-sm rounded border border-border text-text hover:bg-bg"
+          >
+            キャンセル
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="px-4 py-2 text-sm rounded bg-red-600 text-white hover:bg-red-700"
+          >
+            削除
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -20,9 +20,10 @@ function formatDueDate(dueDate: string): { label: string; overdue: boolean } {
 interface Props {
   task: Task;
   onClick?: () => void;
+  onDelete?: (id: number) => void;
 }
 
-export default function TaskCard({ task, onClick }: Props) {
+export default function TaskCard({ task, onClick, onDelete }: Props) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: task.id });
   const priorityBadge = task.priority ? PRIORITY_BADGE[task.priority] : null;
   const due = formatDueDate(task.dueDate);
@@ -40,7 +41,29 @@ export default function TaskCard({ task, onClick }: Props) {
       className="bg-surface rounded shadow-sm px-3 py-2.5 border border-transparent hover:border-border hover:-translate-y-px hover:shadow-md transition-all cursor-grab active:cursor-grabbing"
       onClick={onClick}
     >
-      <p className="text-sm font-medium leading-snug break-words text-text mb-2">{task.title}</p>
+      <div className="flex items-start gap-1 mb-2">
+        <p className="flex-1 text-sm font-medium leading-snug break-words text-text">{task.title}</p>
+        {onDelete && (
+          <button
+            type="button"
+            onPointerDown={e => e.stopPropagation()}
+            onClick={e => {
+              e.stopPropagation();
+              onDelete(task.id);
+            }}
+            className="flex-shrink-0 p-1 rounded text-text-sub hover:text-red-600 hover:bg-red-50"
+            aria-label="タスクを削除"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"
+                 fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="3 6 5 6 21 6"/>
+              <path d="M19 6l-1 14H6L5 6"/>
+              <path d="M10 11v6M14 11v6"/>
+              <path d="M9 6V4h6v2"/>
+            </svg>
+          </button>
+        )}
+      </div>
       <div className="flex items-center gap-1.5 flex-wrap">
         {priorityBadge && (
           <span className={`inline-block text-xs font-semibold px-2 py-0.5 rounded ${priorityBadge.bg} ${priorityBadge.text}`}>


### PR DESCRIPTION
Closes #21

## 変更内容
- バックエンド: `DELETE /api/tasks/{id}` エンドポイントを追加（物理削除）
- フロントエンド: タスクカード上部右にゴミ箱アイコンボタンを常時表示
- フロントエンド: `ConfirmDialog` コンポーネントを新規作成（既存モーダルパターンを踏襲）
- フロントエンド: 確認後、楽観的UIでカードを即座にボードから除去