### PR TITLE
C:/Program Files/Git/server-start スキルに Docker Desktop 自動起動手順を追加

### DIFF
--- a/.claude/commands/server-start.md
+++ b/.claude/commands/server-start.md
@@ -11,6 +11,14 @@
 
 ## 手順
 
-1. 起動対象のデフォルトポートが使用中か確認する
-2. 使用中であれば、そのプロセスをユーザーに確認の上停止する
-3. デフォルトポートで起動する
+1. Docker Desktop が起動しているか確認する（`docker info` で確認）
+2. 起動していない場合は以下のコマンドで起動し、準備完了まで待機する
+   ```bash
+   powershell -Command "Start-Process 'C:\\Program Files\\Docker\\Docker\\Docker Desktop.exe'"
+   # Docker が起動するまで待機（ready になるまでポーリング）
+   for i in $(seq 1 12); do docker info > /dev/null 2>&1 && echo "Docker ready" && break; echo "Waiting... ($i)"; sleep 5; done
+   ```
+3. 起動対象のデフォルトポートが使用中か確認する
+4. 使用中であれば、そのプロセスをユーザーに確認の上停止する
+5. `docker compose up -d` で DB・バックエンドを起動する
+6. `pnpm dev` でフロントエンドを起動する（バックグラウンド実行）


### PR DESCRIPTION
Closes #29

## 変更内容
- Docker Desktop が未起動の場合にコマンドで自動起動する手順を追加
- 起動完了まで待機するポーリング処理を追加
- `docker compose up -d` と `pnpm dev` の起動手順を明示